### PR TITLE
MacPorts PostgreSQL support, removing range-v3 requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,12 @@ find_package(nlohmann_json REQUIRED)
 find_package(SMILEapi REQUIRED)
 find_package(Mosquitto REQUIRED)
 find_package(range-v3 REQUIRED)
+
+# Add additional search paths to get things to work with MacPorts-provided
+# PostgreSQL
+set(PostgreSQL_INCLUDE_ADDITIONAL_SEARCH_SUFFIXES "postgresql14")
+set(PostgreSQL_LIBRARY_ADDITIONAL_SEARCH_SUFFIXES "postgresql14")
+
 find_package(PostgreSQL REQUIRED)
 
 option(BUILD_GOOGLE_CLOUD_SPEECH_LIB "Build google_cloud_speech library" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,6 @@ find_package(
 find_package(nlohmann_json REQUIRED)
 find_package(SMILEapi REQUIRED)
 find_package(Mosquitto REQUIRED)
-find_package(range-v3 REQUIRED)
 
 # Add additional search paths to get things to work with MacPorts-provided
 # PostgreSQL

--- a/src/SpeechWrapper.cpp
+++ b/src/SpeechWrapper.cpp
@@ -7,6 +7,7 @@ using google::cloud::speech::v1::RecognitionConfig;
 using google::cloud::speech::v1::Speech;
 using google::cloud::speech::v1::StreamingRecognizeRequest;
 using google::cloud::speech::v1::StreamingRecognizeResponse;
+using google::cloud::speech::v1::StreamingRecognitionConfig;
 
 using namespace std;
 
@@ -62,9 +63,9 @@ void SpeechWrapper::initialize_stream() {
 void SpeechWrapper::send_config() {
     // Write first request with config
     StreamingRecognizeRequest config_request;
-    auto* streaming_config = config_request.mutable_streaming_config();
+    StreamingRecognitionConfig* streaming_config = config_request.mutable_streaming_config();
 
-    auto mutable_config = streaming_config->mutable_config();
+    RecognitionConfig* mutable_config = streaming_config->mutable_config();
     mutable_config->set_language_code("en");
     mutable_config->set_sample_rate_hertz(this->sample_rate);
     mutable_config->set_encoding(RecognitionConfig::LINEAR16);

--- a/tools/install_dependencies_macports
+++ b/tools/install_dependencies_macports
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Install dependencies for the tomcat-speechAnalyzer program using MacPorts
+
+sudo port -N install \
+    postgresql14\
+    protobuf-c\
+    grpc


### PR DESCRIPTION
This PR introduces a couple of miscellaneous improvements.

- Adds a few lines in CMakeLists.txt to help CMake find MacPorts-provided PostgreSQL 14.
- Adds a script to install dependencies using MacPorts.
- Removes range-v3 dependency since the library is not that stable and was causing compilation errors on macOS. The URL query parameters are now processed using Boost's string algorithms.
- A couple of `auto` type declarations are replaced with the real type of the variable.