### PR TITLE
speechAnalyzer:4.1.1 - Binary audio chunk processing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:impish
 
 #ubuntu setup
 ENV DEBIAN_FRONTEND "noninteractive"
@@ -16,6 +16,9 @@ RUN apt-get update -y && apt-get upgrade -y && \
 
     # Mosquitto
     mosquitto mosquitto-clients libmosquitto-dev \
+    libssl-dev \
+    libpaho-mqttpp-dev \
+    libpaho-mqtt-dev \
 
     # PostgreSQL
     libpq-dev postgresql-server-dev-all

--- a/src/Mosquitto.cpp
+++ b/src/Mosquitto.cpp
@@ -96,6 +96,7 @@ void Mosquitto::mosquitto_callback_on_message(
     mosquitto->on_message(topic, ss.str());
 }
 
+
 //----------------------------------------------------------------------
 // Virtual functions
 //----------------------------------------------------------------------

--- a/src/OpensmileSession.h
+++ b/src/OpensmileSession.h
@@ -5,15 +5,16 @@
 #include <queue>
 #include <thread>
 #include <vector>
-
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 
-#include "JsonBuilder.h"
+#include <mqtt/client.h>
 #include <smileapi/SMILEapi.h>
 
-class OpensmileSession : Mosquitto {
+#include "JsonBuilder.h"
+
+class OpensmileSession{
   public:
     OpensmileSession(std::string participant_id, std::string mqtt_host_internal,
                      int mqtt_port_internal);
@@ -24,14 +25,13 @@ class OpensmileSession : Mosquitto {
     void Shutdown();
     void Loop();
     void PublishChunk(std::vector<float> float_chunk);
-    void on_message(const std::string& topic,
-                    const std::string& message) override;
 
     bool running = false;
     int pid;
 
     std::string mqtt_host_internal;
     int mqtt_port_internal;
+    mqtt::client *mqtt_client;
     std::thread listener_thread;
 
     std::string participant_id;


### PR DESCRIPTION
Audio chunk messages received from the internal message bus are now in raw binary format instead of base64 encoded strings. The decoding code has been updated to reflect this change. Additionally, when interfacing with the internal message bus, the Mosquito wrapper is no longer used due to missing support for binary messages. The paho.mqtt.cpp library is now used instead.

Due to no longer having the decoding overhead, the overall CPU usage has been decreased. When processing three audio streams, the CPU usage stays between 200-300%. 

**Additional change log:**
- Adds paho.mqtt.cpp dependency to CMakeLists
- Upgrades Ubuntu version when building with Docker due to compatibility issues with paho.mqtt.cpp